### PR TITLE
Use read size instead of BUFFER_SIZE to count correctly

### DIFF
--- a/wc-l-syscall.c
+++ b/wc-l-syscall.c
@@ -43,7 +43,7 @@ do_word_count(int fd, const char *path)
         if (n < 0) die(path);
         if (n == 0) break;
         unsigned long i;
-        for (i = 0; i < BUFFER_SIZE; i++) {
+        for (i = 0; i < n; i++) {
             if (buf[i] == '\n') {
                 count++;
             }


### PR DESCRIPTION
This fixes `do_word_count` in `wc-l-syscall.c`.
To correctly count `'\n'`, use read size(variable `n`) instead of `BUFFER_SIZE`.