### PR TITLE
sh1.c修正

### DIFF
--- a/sh1.c
+++ b/sh1.c
@@ -98,7 +98,7 @@ parse_cmd(char *cmdline)
         if (*p) {
             if (cmd->capa <= cmd->argc + 1) {   /* +1 for final NULL */
                 cmd->capa *= 2;
-                cmd->argv = xrealloc(cmd->argv, cmd->capa);
+                cmd->argv = xrealloc(cmd->argv, sizeof(char*) * cmd->capa);
             }
             cmd->argv[cmd->argc] = p;
             cmd->argc++;


### PR DESCRIPTION
sh1.c内の関数parse_cmdの修正

コマンドライン引数が多い場合の、struct cmdのメンバargvのメモリ割り当てを修正した